### PR TITLE
Android Improvements

### DIFF
--- a/RHI/CMakeLists.txt
+++ b/RHI/CMakeLists.txt
@@ -17,7 +17,7 @@ else()
     message(STATUS "This project is a top-level one")
 endif()
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_library(${PROJECT_NAME} STATIC)

--- a/RHI/CMakeLists.txt
+++ b/RHI/CMakeLists.txt
@@ -177,6 +177,7 @@ elseif (ANDROID)
 			"Private/OS/Android/AndroidLog.c"
 			"Private/OS/Android/AndroidFileSystem.cpp"
 			"Private/OS/Android/AndroidTime.c"
+			"Private/FileSystem/UnixFileSystem.c"
 	)
 else ()
 # Core functionalities

--- a/RHI/CMakeLists.txt
+++ b/RHI/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(${PROJECT_NAME} STATIC)
 
 target_include_directories(${PROJECT_NAME}
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty
+	PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/../ThirdParty/agdk/include
     PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/Private
     PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/Public>
 
@@ -109,7 +110,23 @@ set(RHI_SOURCES
 set_source_files_properties(
     ${RHI_SOURCES} PROPERTIES LANGUAGE OBJCXX
 )
-else()
+elseif (ANDROID)
+# RHI (min. requirement for rendering)
+set(RHI_SOURCES
+		"Private/Graphics/CommonShaderReflection.cpp"
+		"Private/Graphics/GraphicsConfig.cpp"
+		"Private/Graphics/PickRenderingApi.cpp"
+
+		"Private/ResourceLoader/ResourceLoader.cpp"
+
+		"Private/Graphics/Vulkan/Vulkan.cpp"
+		"Private/Graphics/Vulkan/VulkanRaytracing.cpp"
+		"Private/Graphics/Vulkan/VulkanShaderReflection.cpp"
+
+		"Private/Fonts/FontSystem.cpp"
+		"Private/Fonts/stbtt.cpp"
+)
+else ()
 # RHI (min. requirement for rendering)
 set(RHI_SOURCES 
 	"Private/Graphics/CommonShaderReflection.cpp"
@@ -150,7 +167,18 @@ set_target_properties(
     PROPERTIES
     XCODE_ATTRIBUTE_CLANG_ENABLE_OBJC_ARC YES  
 )
-else()
+elseif (ANDROID)
+	set(CORE_SOURCES
+			"Private/Log/Log.c"
+			"Private/MemoryTracking/MemoryTracking.c"
+			"Private/FileSystem/FileSystem.c"
+			"Private/OS/Timer.c"
+			"Private/OS/Android/AndroidThread.c"
+			"Private/OS/Android/AndroidLog.c"
+			"Private/OS/Android/AndroidFileSystem.cpp"
+			"Private/OS/Android/AndroidTime.c"
+	)
+else ()
 # Core functionalities
 set(CORE_SOURCES 
 	"Private/Log/Log.c"

--- a/RHI/Private/FileSystem/FileSystem.c
+++ b/RHI/Private/FileSystem/FileSystem.c
@@ -1030,13 +1030,13 @@ void fsSetPathForResourceDir(IFileSystem* pIO, ResourceMount mount, ResourceDire
     strncpy(dir->mPath, resourcePath, FS_MAX_PATH);
     dir->pIO = pIO;
 
-    if (!dir->mBundled && dir->mPath[0] != 0)
+    /*if (!dir->mBundled && dir->mPath[0] != 0)
     {
         if (!fsCreateResourceDirectory(resourceDir))
         {
             LOGF(eERROR, "Could not create direcotry '%s' in filesystem", resourcePath);
         }
-    }
+    }*/
 }
 
 /************************************************************************/

--- a/RHI/Private/Graphics/GraphicsConfig.cpp
+++ b/RHI/Private/Graphics/GraphicsConfig.cpp
@@ -1200,13 +1200,15 @@ GPUPresetLevel getGPUPresetLevel(uint32_t vendorId, uint32_t modelId, const char
             GPUModelDefinition model = gGPUModels[gpuModelIndex];
             if (model.mVendorId == vendorId && model.mDeviceId == modelId && model.mDeviceId)
             {
-                presetLevel = model.mPreset;
-                break;
+                if (!strcmp(modelName, model.mModelName))
+                {
+                    presetLevel = model.mPreset;
+                    break;
+                }
             }
         }
     }
 
-#if defined(ENABLE_GRAPHICS_DEBUG)
     if (presetLevel != GPU_PRESET_NONE)
     {
         LOGF(eINFO, "Setting preset level %s for gpu vendor:%s model:%s", presetLevelToString(presetLevel), vendorName, modelName);
@@ -1217,7 +1219,6 @@ GPUPresetLevel getGPUPresetLevel(uint32_t vendorId, uint32_t modelId, const char
         LOGF(eWARNING, "Couldn't find gpu %s model: %s in gpu.data. Setting preset to %s as a default.", vendorName, modelName,
              presetLevelToString(presetLevel));
     }
-#endif
 
     return presetLevel;
 }

--- a/RHI/Private/Graphics/Vulkan/Vulkan.cpp
+++ b/RHI/Private/Graphics/Vulkan/Vulkan.cpp
@@ -81,7 +81,7 @@
 #endif
 
 #if defined(GFX_ENABLE_SWAPPY)
-#include "swappy/swappyVk.h"
+#include "agdk/include/swappy/swappyVk.h"
 #endif
 
 #include "IMemory.h"
@@ -4068,9 +4068,6 @@ void vk_initRenderer(const char* appName, const RendererDesc* pDesc, Renderer** 
             contextDesc.mEnableShaderStats = pDesc->mEnableShaderStats;
 #endif
 
-#if defined(ANDROID)
-            contextDesc.mPreferVulkan = pDesc->mPreferVulkan;
-#endif
             COMPILE_ASSERT(sizeof(contextDesc.mVk) == sizeof(pDesc->mVk));
             memcpy(&contextDesc.mVk, &pDesc->mVk, sizeof(pDesc->mVk));
             vk_initRendererContext(appName, &contextDesc, &pRenderer->pContext);
@@ -4887,14 +4884,9 @@ void vk_addSwapChain(Renderer* pRenderer, const SwapChainDesc* pDesc, SwapChain*
     if (gSwappyEnabled)
     {
         // Setup Swappy
-        // AndroidWindow.cpp, used to retrieve the Java activity
-        extern WindowDesc gWindow;
         uint64_t          refreshDuration;
 
-        JNIEnv* pJavaEnv = NULL;
-        gWindow.handle.activity->vm->AttachCurrentThread(&pJavaEnv, NULL);
-
-        SwappyVk_initAndGetRefreshCycleDuration(pJavaEnv, gWindow.handle.activity->clazz, pRenderer->pGpu->mVk.pGpu, pRenderer->mVk.pDevice,
+        SwappyVk_initAndGetRefreshCycleDuration(pDesc->mWindowHandle.jniEnv, gWindow.handle.activity->clazz, pRenderer->pGpu->mVk.pGpu, pRenderer->mVk.pDevice,
                                                 vkSwapchain, &refreshDuration);
         SwappyVk_setAutoSwapInterval(false);
         // Don't swap faster than the monitor refresh rate

--- a/RHI/Private/Graphics/Vulkan/Vulkan.cpp
+++ b/RHI/Private/Graphics/Vulkan/Vulkan.cpp
@@ -1343,7 +1343,25 @@ static VkBool32 VKAPI_PTR DebugUtilsCallback(VkDebugUtilsMessageSeverityFlagBits
     }
     else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT)
     {
-        LOGF(LogLevel::eWARNING, "[%s] : %s (%i)", pLayerPrefix, pMessage, messageCode);
+        static const char* messageDataToIgnore[] = {
+                // Weird warning on some Android devices from QC when ending a render pass
+                // Very little info online about it without and sort of lead
+                "The following warning was triggered: VKDBGUTILWARN003. Please refer to the Adreno Game Developer Guide for more information: https://developer.qualcomm.com/docs/adreno-gpu/developer-guide/index.html",
+        };
+
+        bool ignoreWarning = false;
+        for (uint32_t m = 0; m < TF_ARRAY_COUNT(messageDataToIgnore); ++m)
+        {
+            if (strstr(pMessage, messageDataToIgnore[m]))
+            {
+                ignoreWarning = true;
+                break;
+            }
+        }
+        if (!ignoreWarning)
+        {
+            LOGF(LogLevel::eWARNING, "[%s] : %s (%i)", pLayerPrefix, pMessage, messageCode);
+        }
     }
     else if (messageSeverity & VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT)
     {

--- a/RHI/Private/Graphics/Vulkan/Vulkan.cpp
+++ b/RHI/Private/Graphics/Vulkan/Vulkan.cpp
@@ -4886,7 +4886,7 @@ void vk_addSwapChain(Renderer* pRenderer, const SwapChainDesc* pDesc, SwapChain*
         // Setup Swappy
         uint64_t          refreshDuration;
 
-        SwappyVk_initAndGetRefreshCycleDuration(pDesc->mWindowHandle.jniEnv, gWindow.handle.activity->clazz, pRenderer->pGpu->mVk.pGpu, pRenderer->mVk.pDevice,
+        SwappyVk_initAndGetRefreshCycleDuration(pDesc->mWindowHandle.jniEnv, pDesc->mWindowHandle.activity, pRenderer->pGpu->mVk.pGpu, pRenderer->mVk.pDevice,
                                                 vkSwapchain, &refreshDuration);
         SwappyVk_setAutoSwapInterval(false);
         // Don't swap faster than the monitor refresh rate

--- a/RHI/Private/Graphics/Vulkan/Vulkan.cpp
+++ b/RHI/Private/Graphics/Vulkan/Vulkan.cpp
@@ -8992,7 +8992,7 @@ void vk_queuePresent(Queue* pQueue, const QueuePresentDesc* pDesc)
             ASSERT(0);
 #endif
         }
-        else if (vk_res == VK_ERROR_OUT_OF_DATE_KHR)
+        else if (vk_res == VK_ERROR_OUT_OF_DATE_KHR || vk_res == VK_ERROR_SURFACE_LOST_KHR)
         {
             // TODO : Fix bug where we get this error if window is closed before able to present queue.
         }

--- a/RHI/Private/Graphics/Vulkan/Vulkan.cpp
+++ b/RHI/Private/Graphics/Vulkan/Vulkan.cpp
@@ -8799,6 +8799,13 @@ void vk_acquireNextImage(Renderer* pRenderer, SwapChain* pSwapChain, Semaphore* 
             return;
         }
 
+        // VK_ERROR_SURFACE_LOST_KHR can happen on Android when app is put into the background
+        if (vk_res == VK_ERROR_SURFACE_LOST_KHR)
+        {
+            pSignalSemaphore->mVk.mSignaled = true;
+            return;
+        }
+
         CHECK_VKRESULT(vk_res);
         pSignalSemaphore->mVk.mSignaled = true;
     }

--- a/RHI/Private/OS/Android/AndroidFileSystem.cpp
+++ b/RHI/Private/OS/Android/AndroidFileSystem.cpp
@@ -41,7 +41,6 @@ extern "C"
     bool fsMergeDirAndFileName(const char* dir, const char* path, char separator, size_t dstSize, char* dst);
 }
 
-static ANativeActivity* pNativeActivity = NULL;
 static AAssetManager*   pAssetManager = NULL;
 
 static bool        gInitialized = false;
@@ -174,14 +173,13 @@ bool initFileSystem(FileSystemInitDesc* pDesc)
     for (uint32_t i = 0; i < RM_COUNT; ++i)
         gResourceMounts[i] = "";
 
-    pNativeActivity = (ANativeActivity*)pDesc->pPlatformData;
-    ASSERT(pNativeActivity);
+    pAssetManager = (AAssetManager*)pDesc->pPlatformData;
 
-    pAssetManager = pNativeActivity->assetManager;
+    // Following should be set by client
     gResourceMounts[RM_CONTENT] = "\0";
-    gResourceMounts[RM_DEBUG] = pNativeActivity->externalDataPath;
-    gResourceMounts[RM_DOCUMENTS] = pNativeActivity->internalDataPath;
-    gResourceMounts[RM_SAVE_0] = pNativeActivity->externalDataPath;
+    //gResourceMounts[RM_DEBUG] = pNativeActivity->externalDataPath;
+    //gResourceMounts[RM_DOCUMENTS] = pNativeActivity->internalDataPath;
+    //gResourceMounts[RM_SAVE_0] = pNativeActivity->externalDataPath;
     gResourceMounts[RM_SYSTEM] = "/proc/";
 
     // Override Resource mounts

--- a/RHI/Private/OS/Android/AndroidFileSystem.cpp
+++ b/RHI/Private/OS/Android/AndroidFileSystem.cpp
@@ -23,6 +23,7 @@
  */
 
 #include <android/asset_manager.h>
+#include <android/asset_manager_jni.h>
 #include <dirent.h>
 #include <errno.h>
 #include <sys/inotify.h>

--- a/RHI/Private/OS/Android/AndroidLog.c
+++ b/RHI/Private/OS/Android/AndroidLog.c
@@ -23,6 +23,7 @@
  */
 #ifdef __ANDROID__
 
+#include <android/log.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>

--- a/RHI/Public/Config.h
+++ b/RHI/Public/Config.h
@@ -230,7 +230,9 @@ COMPILE_ASSERT(sizeof(ssize_t) == sizeof(int64_t));
 #endif
 
 #elif defined(__ANDROID__)
+#ifndef ANDROID
 #define ANDROID
+#endif
 #elif defined(__ORBIS__)
 #define ORBIS
 #elif defined(__PROSPERO__)

--- a/RHI/Public/IGraphics.h
+++ b/RHI/Public/IGraphics.h
@@ -2534,10 +2534,6 @@ typedef struct RendererDesc
 #if defined(SHADER_STATS_AVAILABLE)
     bool mEnableShaderStats;
 #endif
-
-#if defined(VULKAN) && defined(ANDROID)
-    bool mPreferVulkan;
-#endif
 } RendererDesc;
 
 typedef struct GPUVendorPreset
@@ -2764,10 +2760,6 @@ typedef struct RendererContextDesc
     bool mEnableGpuBasedValidation;
 #if defined(SHADER_STATS_AVAILABLE)
     bool mEnableShaderStats;
-#endif
-
-#if defined(VULKAN) && defined(ANDROID)
-    bool mPreferVulkan;
 #endif
 } RendererContextDesc;
 

--- a/RHI/Public/IOperatingSystem.h
+++ b/RHI/Public/IOperatingSystem.h
@@ -53,7 +53,7 @@ typedef uint64_t uint64;
 
 #elif defined(__ANDROID__)
 #include <android/log.h>
-#include <android_native_app_glue.h>
+#include <android/native_window.h>
 
 #elif defined(__linux__) && !defined(VK_USE_PLATFORM_GGP)
 #define VK_USE_PLATFORM_XLIB_KHR
@@ -117,8 +117,7 @@ typedef struct WindowHandle
     HWND window;
 #elif defined(ANDROID)
     ANativeWindow* window;
-    ANativeActivity* activity;
-    AConfiguration* configuration;
+    JNIEnv* jniEnv;
 #elif defined(__APPLE__) || defined(NX64) || defined(ORBIS) || defined(PROSPERO)
     void* window;
 #elif defined(VK_USE_PLATFORM_XCB_KHR)

--- a/RHI/Public/IOperatingSystem.h
+++ b/RHI/Public/IOperatingSystem.h
@@ -118,6 +118,7 @@ typedef struct WindowHandle
 #elif defined(ANDROID)
     ANativeWindow* window;
     JNIEnv* jniEnv;
+    jobject activity;
 #elif defined(__APPLE__) || defined(NX64) || defined(ORBIS) || defined(PROSPERO)
     void* window;
 #elif defined(VK_USE_PLATFORM_XCB_KHR)


### PR DESCRIPTION
- GPU config should check model name when dictating presets instead of just vendor/device ID.
- No assertion on VK_ERROR_SURFACE_LOST_KHR, it's not an error and app should handle it properly.
- Ignoring weird VK log from QC's debug layer
- Android build updates to cmake